### PR TITLE
Make java compiler target version 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.3</version>
         <configuration>
           <source>1.5</source>
           <target>1.5</target>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,15 @@
 	<build>
 		<plugins>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin> 
+
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>appassembler-maven-plugin</artifactId>


### PR DESCRIPTION
I'm relatively new to Maven, but Maven 3.0.5 on Ubuntu 14.10 appears to default to compiling with a Java 1.3 target. This causes the build to break because of generics usage. Maven 3.0.5 is allowed because the pom.xml gives 3.0.4 as the minimum req.

This patch explicitly targets Java 1.5 in the pom.xml which allows a successful build.
