### PR TITLE
Dictionaries to use resources not hardcoded files

### DIFF
--- a/src/main/java/org/xmlcml/ami2/dictionary/gene/HGNCDictionary.java
+++ b/src/main/java/org/xmlcml/ami2/dictionary/gene/HGNCDictionary.java
@@ -66,7 +66,7 @@ public class HGNCDictionary extends DefaultAMIDictionary {
 
 	private void readHGNCJson() {
 		try {
-			createFromInputStream(HGNC, new FileInputStream(HGNC_JSON_FILE));
+			createFromInputStream(HGNC, ClassLoader.getSystemResourceAsStream("src/main/resources/org/xmlcml/ami2/plugins/gene/hgnc/_complete_set.json"));
 			String resultsJsonString = IOUtils.toString(inputStream, UTF_8);
 		    JsonParser parser = new JsonParser();
 		    hgncJson = (JsonObject) parser.parse(resultsJsonString);

--- a/src/main/java/org/xmlcml/ami2/dictionary/gene/JAXDictionary.java
+++ b/src/main/java/org/xmlcml/ami2/dictionary/gene/JAXDictionary.java
@@ -50,7 +50,8 @@ public class JAXDictionary extends DefaultAMIDictionary {
 
 	private void readJAX_XML() {
 		if (!JAX_XML_FILE.exists()) {
-			readJAXTSV(JAX_TSV_FILE);
+			File JAX_TSV_RES = new File(getClass().getClassLoader().getResource("org/xmlcml/ami2/plugins/genes/jax/MGI_Gene_Model_Coord.tsv").getFile());
+			readJAXTSV(JAX_TSV_RES);
 			dictionaryElement = createDictionaryElementFromHashMap("jax");
 			writeXMLFile(JAX_XML_FILE);
 		} else {

--- a/src/main/java/org/xmlcml/ami2/dictionary/species/TaxDumpGenusDictionary.java
+++ b/src/main/java/org/xmlcml/ami2/dictionary/species/TaxDumpGenusDictionary.java
@@ -33,13 +33,16 @@ public class TaxDumpGenusDictionary extends DefaultAMIDictionary {
 	}
 
 	private void readTAXDUMPXML() {
-		if (!TAXDUMP_XML_FILE.exists()) {
+		ClassLoader classLoader = getClass().getClassLoader();
+		LOG.debug(TAXDUMP_XML_FILE.getPath());
+		File TAXDUMP_XML_RES = new File(getClass().getClassLoader().getResource("org/xmlcml/ami2/plugins/species/taxdump/taxdumpGenus.xml").getFile());
+		if (!TAXDUMP_XML_RES.exists()) {
 			// read text file
 //			readTAXDUMPJson();
 //			createDictionaryElementFromHashMap(TAXDUMP);
 //			writeXMLFile(TAXDUMP_XML_FILE);
 		} else {
-			readDictionary(TAXDUMP_XML_FILE);
+			readDictionary(TAXDUMP_XML_RES);
 		}
 	}
 

--- a/src/main/java/org/xmlcml/ami2/dictionary/synbio/SynbioDictionary.java
+++ b/src/main/java/org/xmlcml/ami2/dictionary/synbio/SynbioDictionary.java
@@ -24,7 +24,8 @@ public class SynbioDictionary extends DefaultAMIDictionary {
 	}
 	
 	private void init() {
-		readDictionary(SYNBIO_XML_FILE);
+		ClassLoader cl = getClass().getClassLoader();
+		readDictionary(new File(cl.getResource("org/xmlcml/ami2/plugins/synbio/synbio.xml").getFile()));
 	}
 
 


### PR DESCRIPTION
A quick hack to make dictionaries a resource rather than hardcoded links so that the commands will work independent of where you are on the file system. Long term we will have dictionaries neatly sorted in a separate repo to solve this elegantly.

This closes #32
